### PR TITLE
Add colorBounds param to control colorscale range

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Creates a surface plot object.  `params` is an object with any of the following 
 * `field` a new 2D field encoded as an ndarray
 * `coords` is an array of 3 2D fields, each encoded as ndarrays (for parameteric surfaces)
 * `colormap` the name of the new color map for the surface
+* `colorBounds` sets the z range for the colormap
 * `ticks` is a pair of arrays of ticks representing the spacing of the points for the axes of the surface
 * `showSurface` if set, draw the surface
 * `showContour` if set, draw contour lines

--- a/example/example.js
+++ b/example/example.js
@@ -3,13 +3,13 @@
 var shell = require("gl-now")({ clearColor: [0,0,0,0] })
 var camera = require("game-shell-orbit-camera")(shell)
 var createSurface = require("../surface.js")
-var createAxes = require("gl-axes")
-var createSpikes = require("gl-spikes")
+var createAxes = require("gl-axes3d")
+var createSpikes = require("gl-spikes3d")
 var ndarray = require("ndarray")
 var fill = require("ndarray-fill")
 var diric = require("dirichlet")
 var glm = require("gl-matrix")
-var createSelect = require("gl-select")
+var createSelect = require("gl-select-static")
 var mat4 = glm.mat4
 
 var surface, spikes, axes, select, target = null
@@ -37,7 +37,8 @@ shell.on("gl-init", function() {
 
   var coords = [
     ndarray(new Float32Array(4*(size+1)*(size+1)), [2*size+1,2*size+1]),
-    ndarray(new Float32Array(4*(size+1)*(size+1)), [2*size+1,2*size+1])
+    ndarray(new Float32Array(4*(size+1)*(size+1)), [2*size+1,2*size+1]),
+    field
   ]
 
   var x = coords[0]

--- a/surface.js
+++ b/surface.js
@@ -66,10 +66,12 @@ function SurfacePickResult(position, index, uv, level, dataCoordinate) {
   this.dataCoordinate = dataCoordinate
 }
 
+var N_COLORS = 265
+
 function genColormap(name) {
   var x = pack([colormap({
     colormap: name,
-    nshades: 256,
+    nshades: N_COLORS,
     format: 'rgba'
   }).map(function(c) {
     return [c[0], c[1], c[2], 255*c[3]]
@@ -1239,7 +1241,7 @@ function createSurfacePlot(params) {
       type: gl.FLOAT
     }])
 
-  var cmap = createTexture(gl, 1, 256, gl.RGBA, gl.UNSIGNED_BYTE)
+  var cmap = createTexture(gl, 1, N_COLORS, gl.RGBA, gl.UNSIGNED_BYTE)
   cmap.minFilter = gl.LINEAR
   cmap.magFilter = gl.LINEAR
 

--- a/surface.js
+++ b/surface.js
@@ -155,6 +155,8 @@ function SurfacePlot(
                              [ false, false, false ],
                              [ false, false, false ]]
 
+  this.colorBounds        = [ false, false ]
+
   //Store xyz fields, need this for picking
   this._field             = [
       ndarray(pool.mallocFloat(1024), [0,0]),
@@ -296,8 +298,8 @@ function drawCore(params, transparent) {
   uniforms.model        = params.model || IDENTITY
   uniforms.view         = params.view || IDENTITY
   uniforms.projection   = params.projection || IDENTITY
-  uniforms.lowerBound   = this.bounds[0]
-  uniforms.upperBound   = this.bounds[1]
+  uniforms.lowerBound   = [this.bounds[0][0], this.bounds[0][1], this.colorBounds[0] || this.bounds[0][2]]
+  uniforms.upperBound   = [this.bounds[1][0], this.bounds[1][1], this.colorBounds[1] || this.bounds[1][2]]
   uniforms.contourColor = this.contourColor[0]
 
   uniforms.inverseModel = invert(uniforms.inverseModel, uniforms.model)
@@ -747,6 +749,9 @@ proto.update = function(params) {
   }
   if('opacity' in params) {
     this.opacity = params.opacity
+  }
+  if('colorBounds' in params) {
+    this.colorBounds = params.colorBounds
   }
 
   var field = params.field || (params.coords && params.coords[2]) || null


### PR DESCRIPTION
Resolves https://github.com/gl-vis/gl-surface3d/issues/4

More background info in: https://github.com/plotly/plotly.js/issues/86

This PR adds the ability to control the colorscale range with a `colorBounds` parameter. 

The current behavior where the surface coloring is based only on the min and the max of the field array is kept as the default.
