### PR TITLE
Add intensity parameter

### DIFF
--- a/lib/shaders.js
+++ b/lib/shaders.js
@@ -9,7 +9,7 @@ var pickSrc = glslify('../shaders/pick.glsl')
 exports.createShader = function(gl) {
   var shader = createShader(gl, vertSrc, fragSrc, null, [
     {name: 'uv', type: 'vec4'},
-    {name: 'f', type: 'vec2'},
+    {name: 'f', type: 'vec3'},
     {name: 'normal', type: 'vec3'}
   ])
   shader.attributes.uv.location = 0
@@ -20,7 +20,7 @@ exports.createShader = function(gl) {
 exports.createPickShader = function(gl) {
   var shader = createShader(gl, vertSrc, pickSrc, null, [
     {name: 'uv', type: 'vec4'},
-    {name: 'f', type: 'vec2'},
+    {name: 'f', type: 'vec3'},
     {name: 'normal', type: 'vec3'}
   ])
   shader.attributes.uv.location = 0

--- a/shaders/contour-vertex.glsl
+++ b/shaders/contour-vertex.glsl
@@ -19,7 +19,7 @@ void main() {
   clipPosition.z = clipPosition.z + zOffset;
 
   gl_Position = clipPosition;
-  value = dataCoordinate.z;
+  value = uv.z;
   kill = -1.0;
   worldCoordinate = dataCoordinate;
   planeCoordinate = uv.zw;

--- a/shaders/fragment.glsl
+++ b/shaders/fragment.glsl
@@ -3,7 +3,6 @@ precision mediump float;
 #pragma glslify: beckmann = require(glsl-specular-beckmann)
 
 uniform vec3 lowerBound, upperBound;
-uniform vec2 intensityBounds;
 uniform float contourTint;
 uniform vec4 contourColor;
 uniform sampler2D colormap;
@@ -31,8 +30,7 @@ void main() {
   float specular = beckmann(L, V, N, roughness);
   float diffuse  = min(kambient + kdiffuse * max(dot(N, L), 0.0), 1.0);
 
-  float interpValue = (value - intensityBounds.x) / (intensityBounds.y - intensityBounds.x);
-  vec4 surfaceColor = texture2D(colormap, vec2(interpValue, interpValue));
+  vec4 surfaceColor = texture2D(colormap, vec2(value, value));
   vec4 litColor = surfaceColor.a * vec4(diffuse * surfaceColor.rgb + kspecular * vec3(1,1,1) * specular,  1.0);
 
   gl_FragColor = mix(litColor, contourColor, contourTint) * opacity;

--- a/shaders/fragment.glsl
+++ b/shaders/fragment.glsl
@@ -3,6 +3,7 @@ precision mediump float;
 #pragma glslify: beckmann = require(glsl-specular-beckmann)
 
 uniform vec3 lowerBound, upperBound;
+uniform vec2 intensityBounds;
 uniform float contourTint;
 uniform vec4 contourColor;
 uniform sampler2D colormap;
@@ -30,7 +31,7 @@ void main() {
   float specular = beckmann(L, V, N, roughness);
   float diffuse  = min(kambient + kdiffuse * max(dot(N, L), 0.0), 1.0);
 
-  float interpValue = (value - lowerBound.z) / (upperBound.z - lowerBound.z);
+  float interpValue = (value - intensityBounds.x) / (intensityBounds.y - intensityBounds.x);
   vec4 surfaceColor = texture2D(colormap, vec2(interpValue, interpValue));
   vec4 litColor = surfaceColor.a * vec4(diffuse * surfaceColor.rgb + kspecular * vec3(1,1,1) * specular,  1.0);
 

--- a/shaders/vertex.glsl
+++ b/shaders/vertex.glsl
@@ -1,7 +1,7 @@
 precision mediump float;
 
 attribute vec4 uv;
-attribute vec2 f;
+attribute vec3 f;
 attribute vec3 normal;
 
 uniform mat4 model, view, projection, inverseModel;
@@ -17,10 +17,10 @@ void main() {
   vec4 worldPosition = model * vec4(worldCoordinate, 1.0);
   vec4 clipPosition = projection * view * worldPosition;
   gl_Position = clipPosition;
-  value = f.x;
   kill = f.y;
+  value = f.z;
   planeCoordinate = uv.xy;
-  
+
   //Lighting geometry parameters
   vec4 cameraCoordinate = view * worldPosition;
   cameraCoordinate.xyz /= cameraCoordinate.w;

--- a/surface.js
+++ b/surface.js
@@ -24,7 +24,7 @@ var createContourShader     = shaders.createContourShader
 var createPickShader        = shaders.createPickShader
 var createPickContourShader = shaders.createPickContourShader
 
-var SURFACE_VERTEX_SIZE = 4 * (4 + 2 + 3)
+var SURFACE_VERTEX_SIZE = 4 * (4 + 3 + 3)
 
 var IDENTITY = [
   1, 0, 0, 0,
@@ -266,6 +266,7 @@ var UNIFORMS = {
   inverseModel: IDENTITY.slice(),
   lowerBound: [0,0,0],
   upperBound: [0,0,0],
+  intensityBounds: [0,0],
   colorMap:   0,
   clipBounds: [[0,0,0], [0,0,0]],
   height:     0.0,
@@ -301,6 +302,7 @@ function drawCore(params, transparent) {
   uniforms.lowerBound   = [this.bounds[0][0], this.bounds[0][1], this.colorBounds[0] || this.bounds[0][2]]
   uniforms.upperBound   = [this.bounds[1][0], this.bounds[1][1], this.colorBounds[1] || this.bounds[1][2]]
   uniforms.contourColor = this.contourColor[0]
+  uniforms.intensityBounds = this.intensityBounds
 
   uniforms.inverseModel = invert(uniforms.inverseModel, uniforms.model)
 
@@ -892,8 +894,10 @@ proto.update = function(params) {
     //Initialize surface
     var lo = [ Infinity, Infinity, Infinity]
     var hi = [-Infinity,-Infinity,-Infinity]
+    var lo_intensity =  Infinity
+    var hi_intensity = -Infinity
     var count   = (shape[0]-1) * (shape[1]-1) * 6
-    var tverts  = pool.mallocFloat(bits.nextPow2(9*count))
+    var tverts  = pool.mallocFloat(bits.nextPow2(10*count))
     var tptr    = 0
     var fptr    = 0
     var vertexCount = 0
@@ -919,9 +923,14 @@ proto.update = function(params) {
           var tx = this._field[0].get(r+1, c+1)
           var ty = this._field[1].get(r+1, c+1)
           var f  = this._field[2].get(r+1, c+1)
+          var vf = f
           var nx = normals.get(r+1, c+1, 0)
           var ny = normals.get(r+1, c+1, 1)
           var nz = normals.get(r+1, c+1, 2)
+
+          if(params.intensity) {
+            vf = params.intensity.get(r, c)
+          }
 
           tverts[tptr++] = r
           tverts[tptr++] = c
@@ -929,6 +938,7 @@ proto.update = function(params) {
           tverts[tptr++] = ty
           tverts[tptr++] = f
           tverts[tptr++] = 0
+          tverts[tptr++] = vf
           tverts[tptr++] = nx
           tverts[tptr++] = ny
           tverts[tptr++] = nz
@@ -936,10 +946,12 @@ proto.update = function(params) {
           lo[0] = Math.min(lo[0], tx)
           lo[1] = Math.min(lo[1], ty)
           lo[2] = Math.min(lo[2], f)
+          lo_intensity = Math.min(lo_intensity, vf)
 
           hi[0] = Math.max(hi[0], tx)
           hi[1] = Math.max(hi[1], ty)
           hi[2] = Math.max(hi[2], f)
+          hi_intensity = Math.max(hi_intensity, vf)
 
           vertexCount += 1
         }
@@ -952,6 +964,7 @@ proto.update = function(params) {
 
     //Update bounds
     this.bounds = [lo, hi]
+    this.intensityBounds = [lo_intensity, hi_intensity]
   }
 
   //Update level crossings
@@ -1219,7 +1232,7 @@ function createSurfacePlot(params) {
         offset: 0
       },
       { buffer: coordinateBuffer,
-        size: 2,
+        size: 3,
         stride: SURFACE_VERTEX_SIZE,
         offset: 16
       },
@@ -1227,7 +1240,7 @@ function createSurfacePlot(params) {
         buffer: coordinateBuffer,
         size: 3,
         stride: SURFACE_VERTEX_SIZE,
-        offset: 24
+        offset: 28
       }
     ])
 

--- a/surface.js
+++ b/surface.js
@@ -266,7 +266,6 @@ var UNIFORMS = {
   inverseModel: IDENTITY.slice(),
   lowerBound: [0,0,0],
   upperBound: [0,0,0],
-  intensityBounds: [0,0],
   colorMap:   0,
   clipBounds: [[0,0,0], [0,0,0]],
   height:     0.0,
@@ -302,7 +301,6 @@ function drawCore(params, transparent) {
   uniforms.lowerBound   = [this.bounds[0][0], this.bounds[0][1], this.colorBounds[0] || this.bounds[0][2]]
   uniforms.upperBound   = [this.bounds[1][0], this.bounds[1][1], this.colorBounds[1] || this.bounds[1][2]]
   uniforms.contourColor = this.contourColor[0]
-  uniforms.intensityBounds = this.intensityBounds
 
   uniforms.inverseModel = invert(uniforms.inverseModel, uniforms.model)
 
@@ -957,6 +955,17 @@ proto.update = function(params) {
         }
       }
     }
+
+    if(params.intensityBounds) {
+      lo_intensity = +params.intensityBounds[0]
+      hi_intensity = +params.intensityBounds[1]
+    }
+
+    //Scale all vertex intensities
+    for(var i=6; i<tptr; i+=10) {
+      tverts[i] = (tverts[i] - lo_intensity) / (hi_intensity - lo_intensity)
+    }
+
     this._vertexCount = vertexCount
     this._coordinateBuffer.update(tverts.subarray(0,tptr))
     pool.freeFloat(tverts)
@@ -964,7 +973,6 @@ proto.update = function(params) {
 
     //Update bounds
     this.bounds = [lo, hi]
-    this.intensityBounds = [lo_intensity, hi_intensity]
   }
 
   //Update level crossings


### PR DESCRIPTION
This PR adds a new parameter for specifying surface intensity, similar to mesh3d.  For example,  here is how to draw a donut where the theta uv parameter is mapped to surface color:

``` javascript
var createScene = require('gl-plot3d')
var createSurface = require('gl-surface3d')
var ndarray = require('ndarray')

var scene = createScene()

//Create parameters for a torus
var size = 64
var coords = [
  ndarray(new Float32Array(4*(size+1)*(size+1)), [2*size+1,2*size+1]),
  ndarray(new Float32Array(4*(size+1)*(size+1)), [2*size+1,2*size+1]),
  ndarray(new Float32Array(4*(size+1)*(size+1)), [2*size+1,2*size+1])
]
var intensity = ndarray(
  new Float32Array(4*(size+1)*(size+1)), [2*size+1,2*size+1])
for(var i=0; i<=2*size; ++i) {
  var theta = Math.PI * (i - size) / size
  for(var j=0; j<=2*size; ++j) {
    var phi = Math.PI * (j - size) / size
    coords[0].set(i, j, (50.0 + 20.0 * Math.cos(theta)) * Math.cos(phi))
    coords[1].set(i, j, (50.0 + 20.0 * Math.cos(theta)) * Math.sin(phi))
    coords[2].set(i, j, 20.0 * Math.sin(theta))

    intensity.set(i, j, theta)
  }
}

var contourLevels = [[0], [0], [0]]

var surface = createSurface({
  gl:  scene.gl,
  levels: [ contourLevels, contourLevels, contourLevels ],
  lineWidth: 3,
  contourTint: 1,
  coords: coords,
  contourProject: [
    [true,false,false],
    [false,true,false],
    [false,false,true] ],
  intensity: intensity,
  showContour: true
})

scene.add(surface)
```

<img width="311" alt="screen shot 2016-03-03 at 1 53 57 pm" src="https://cloud.githubusercontent.com/assets/231686/13510845/6c7c0eb2-e147-11e5-8b2b-816a73e7e7b9.png">

CC @etpinard 
