### PR TITLE
scale contour intensity to intensityBounds

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,8 +50,9 @@ Creates a surface plot object.  `params` is an object with any of the following 
 * `gl` is a WebGL context
 * `field` a new 2D field encoded as an ndarray
 * `coords` is an array of 3 2D fields, each encoded as ndarrays (for parameteric surfaces)
-* `colormap` the name of the new color map for the surface
-* `colorBounds` sets the z range for the colormap
+* `intensity` a 2D intensity field (defaults to `field` or `coords[2] is not present)
+* `colormap` the name of the new color map for the surface (see list of names in `colormap` [docs](https://github.com/bpostlethwaite/colormap))
+* `intensityBounds` sets the intensity range for the colormap
 * `ticks` is a pair of arrays of ticks representing the spacing of the points for the axes of the surface
 * `showSurface` if set, draw the surface
 * `showContour` if set, draw contour lines

--- a/surface.js
+++ b/surface.js
@@ -97,6 +97,7 @@ function SurfacePlot (
   this.gl = gl
   this.shape = shape
   this.bounds = bounds
+  this.intensityBounds = [];
 
   this._shader = shader
   this._pickShader = pickShader
@@ -750,6 +751,7 @@ proto.update = function (params) {
   }
 
   var field = params.field || (params.coords && params.coords[2]) || null
+  var levelsChanged = false
 
   if (!field) {
     if (this._field[2].shape[0] || this._field[2].shape[2]) {
@@ -969,12 +971,15 @@ proto.update = function (params) {
     // Save intensity
     this.intensity = params.intensity || this._field[2]
 
+    if(this.intensityBounds[0] !== lo_intensity || this.intensityBounds[1] !== hi_intensity) {
+        levelsChanged = true
+    }
+
     // Save intensity bound
     this.intensityBounds = [lo_intensity, hi_intensity]
   }
 
   // Update level crossings
-  var levelsChanged = false
   if ('levels' in params) {
     var levels = params.levels
     if (!Array.isArray(levels[0])) {

--- a/surface.js
+++ b/surface.js
@@ -968,6 +968,9 @@ proto.update = function (params) {
 
     // Save intensity
     this.intensity = params.intensity || this._field[2]
+
+    // Save intensity bound
+    this.intensityBounds = [lo_intensity, hi_intensity]
   }
 
   // Update level crossings
@@ -1049,7 +1052,7 @@ proto.update = function (params) {
                   if (dd < 2) {
                     f = this._field[iu].get(r, c)
                   } else {
-                    f = this.intensity.get(r, c)
+                    f = (this.intensity.get(r, c) - this.intensityBounds[0]) / (this.intensityBounds[1] - this.intensityBounds[0])
                   }
                   if (!isFinite(f) || isNaN(f)) {
                     hole = true


### PR DESCRIPTION
@mikolalysenko 

This [line](https://github.com/gl-vis/gl-surface3d/pull/6/files#diff-25ca11a30189a873f81fbb2edf9f470aR966) added in https://github.com/gl-vis/gl-surface3d/pull/6 scaled the intensity field about the `intensityBounds` (either user-provided or computed in this module) for the `coordinateBuffer` but left the `contourBuffer` un-scaled, resulting in the [`wire-surface`](https://github.com/plotly/plotly.js/blob/master/test/image/baselines/gl3d_wire-surface.png) mock to fail.
