### PR TITLE
gl-surface3d - Adding objectOffset to help maintain the quality of data visualisation 

### DIFF
--- a/shaders/contour-vertex.glsl
+++ b/shaders/contour-vertex.glsl
@@ -24,7 +24,7 @@ void main() {
   clipPosition.z += zOffset;
 
   gl_Position = clipPosition;
-  value = f;
+  value = f + objectOffset.z;
   kill = -1.0;
   planeCoordinate = uv.zw;
 

--- a/shaders/contour-vertex.glsl
+++ b/shaders/contour-vertex.glsl
@@ -1,8 +1,9 @@
-precision mediump float;
+precision highp float;
 
 attribute vec4 uv;
 attribute float f;
 
+uniform vec3 objectOffset;
 uniform mat3 permutation;
 uniform mat4 model, view, projection;
 uniform float height, zOffset;
@@ -16,15 +17,15 @@ varying vec4 vColor;
 
 void main() {
   vec3 dataCoordinate = permutation * vec3(uv.xy, height);
-  vec4 worldPosition = model * vec4(dataCoordinate, 1.0);
+  worldCoordinate = objectOffset + dataCoordinate;
+  vec4 worldPosition = model * vec4(worldCoordinate, 1.0);
 
   vec4 clipPosition = projection * view * worldPosition;
-  clipPosition.z = clipPosition.z + zOffset;
+  clipPosition.z += zOffset;
 
   gl_Position = clipPosition;
   value = f;
   kill = -1.0;
-  worldCoordinate = dataCoordinate;
   planeCoordinate = uv.zw;
 
   vColor = texture2D(colormap, vec2(value, value));

--- a/shaders/contour-vertex.glsl
+++ b/shaders/contour-vertex.glsl
@@ -1,4 +1,4 @@
-precision highp float;
+precision mediump float;
 
 attribute vec4 uv;
 attribute float f;

--- a/shaders/fragment.glsl
+++ b/shaders/fragment.glsl
@@ -3,6 +3,7 @@ precision highp float;
 #pragma glslify: beckmann = require(glsl-specular-beckmann)
 #pragma glslify: outOfRange = require(glsl-out-of-range)
 
+uniform vec3 objectOffset;
 uniform vec3 lowerBound, upperBound;
 uniform float contourTint;
 uniform vec4 contourColor;
@@ -32,7 +33,13 @@ void main() {
   float diffuse  = min(kambient + kdiffuse * max(dot(N, L), 0.0), 1.0);
 
   //decide how to interpolate color — in vertex or in fragment
-  vec4 surfaceColor = step(vertexColor, .5) * texture2D(colormap, vec2(value, value)) + step(.5, vertexColor) * vColor;
+  vec4 surfaceColor = step(vertexColor, .5) *
+    texture2D(colormap,
+      vec2(
+            value + objectOffset.z,
+            value + objectOffset.z
+      )
+    ) + step(.5, vertexColor) * vColor;
 
   vec4 litColor = surfaceColor.a * vec4(diffuse * surfaceColor.rgb + kspecular * vec3(1,1,1) * specular,  1.0);
 

--- a/shaders/fragment.glsl
+++ b/shaders/fragment.glsl
@@ -17,8 +17,8 @@ varying vec3 lightDirection, eyeDirection, surfaceNormal;
 varying vec4 vColor;
 
 void main() {
-  //if ((kill > 0.0) ||
-  //    (outOfRange(clipBounds[0], clipBounds[1], worldCoordinate))) discard;
+  if ((kill > 0.0) ||
+      (outOfRange(clipBounds[0], clipBounds[1], worldCoordinate))) discard;
 
   vec3 N = normalize(surfaceNormal);
   vec3 V = normalize(eyeDirection);

--- a/shaders/fragment.glsl
+++ b/shaders/fragment.glsl
@@ -3,7 +3,6 @@ precision mediump float;
 #pragma glslify: beckmann = require(glsl-specular-beckmann)
 #pragma glslify: outOfRange = require(glsl-out-of-range)
 
-uniform vec3 objectOffset;
 uniform vec3 lowerBound, upperBound;
 uniform float contourTint;
 uniform vec4 contourColor;

--- a/shaders/fragment.glsl
+++ b/shaders/fragment.glsl
@@ -33,13 +33,9 @@ void main() {
   float diffuse  = min(kambient + kdiffuse * max(dot(N, L), 0.0), 1.0);
 
   //decide how to interpolate color — in vertex or in fragment
-  vec4 surfaceColor = step(vertexColor, .5) *
-    texture2D(colormap,
-      vec2(
-            value + objectOffset.z,
-            value + objectOffset.z
-      )
-    ) + step(.5, vertexColor) * vColor;
+  vec4 surfaceColor =
+    step(vertexColor, .5) * texture2D(colormap, vec2(value, value)) +
+    step(.5, vertexColor) * vColor;
 
   vec4 litColor = surfaceColor.a * vec4(diffuse * surfaceColor.rgb + kspecular * vec3(1,1,1) * specular,  1.0);
 

--- a/shaders/fragment.glsl
+++ b/shaders/fragment.glsl
@@ -1,4 +1,4 @@
-precision mediump float;
+precision highp float;
 
 #pragma glslify: beckmann = require(glsl-specular-beckmann)
 #pragma glslify: outOfRange = require(glsl-out-of-range)
@@ -17,8 +17,8 @@ varying vec3 lightDirection, eyeDirection, surfaceNormal;
 varying vec4 vColor;
 
 void main() {
-  if ((kill > 0.0) ||
-      (outOfRange(clipBounds[0], clipBounds[1], worldCoordinate))) discard;
+  //if ((kill > 0.0) ||
+  //    (outOfRange(clipBounds[0], clipBounds[1], worldCoordinate))) discard;
 
   vec3 N = normalize(surfaceNormal);
   vec3 V = normalize(eyeDirection);

--- a/shaders/fragment.glsl
+++ b/shaders/fragment.glsl
@@ -1,4 +1,4 @@
-precision highp float;
+precision mediump float;
 
 #pragma glslify: beckmann = require(glsl-specular-beckmann)
 #pragma glslify: outOfRange = require(glsl-out-of-range)

--- a/shaders/pick.glsl
+++ b/shaders/pick.glsl
@@ -19,8 +19,8 @@ vec2 splitFloat(float v) {
 }
 
 void main() {
-  //if ((kill > 0.0) ||
-  //    (outOfRange(clipBounds[0], clipBounds[1], worldCoordinate))) discard;
+  if ((kill > 0.0) ||
+      (outOfRange(clipBounds[0], clipBounds[1], worldCoordinate))) discard;
 
   vec2 ux = splitFloat(planeCoordinate.x / shape.x);
   vec2 uy = splitFloat(planeCoordinate.y / shape.y);

--- a/shaders/pick.glsl
+++ b/shaders/pick.glsl
@@ -1,4 +1,4 @@
-precision mediump float;
+precision highp float;
 
 #pragma glslify: outOfRange = require(glsl-out-of-range)
 
@@ -19,8 +19,8 @@ vec2 splitFloat(float v) {
 }
 
 void main() {
-  if ((kill > 0.0) ||
-      (outOfRange(clipBounds[0], clipBounds[1], worldCoordinate))) discard;
+  //if ((kill > 0.0) ||
+  //    (outOfRange(clipBounds[0], clipBounds[1], worldCoordinate))) discard;
 
   vec2 ux = splitFloat(planeCoordinate.x / shape.x);
   vec2 uy = splitFloat(planeCoordinate.y / shape.y);

--- a/shaders/pick.glsl
+++ b/shaders/pick.glsl
@@ -1,4 +1,4 @@
-precision highp float;
+precision mediump float;
 
 #pragma glslify: outOfRange = require(glsl-out-of-range)
 

--- a/shaders/vertex.glsl
+++ b/shaders/vertex.glsl
@@ -1,4 +1,4 @@
-precision highp float;
+precision mediump float;
 
 attribute vec4 uv;
 attribute vec3 f;

--- a/shaders/vertex.glsl
+++ b/shaders/vertex.glsl
@@ -1,9 +1,10 @@
-precision mediump float;
+precision highp float;
 
 attribute vec4 uv;
 attribute vec3 f;
 attribute vec3 normal;
 
+uniform vec3 objectOffset;
 uniform mat4 model, view, projection, inverseModel;
 uniform vec3 lightPosition, eyePosition;
 uniform sampler2D colormap;
@@ -16,7 +17,7 @@ varying vec4 vColor;
 
 void main() {
   worldCoordinate = vec3(uv.zw, f.x);
-  vec4 worldPosition = model * vec4(worldCoordinate, 1.0);
+  vec4 worldPosition = model * vec4(objectOffset + worldCoordinate, 1.0);
   vec4 clipPosition = projection * view * worldPosition;
   gl_Position = clipPosition;
   kill = f.y;

--- a/shaders/vertex.glsl
+++ b/shaders/vertex.glsl
@@ -16,8 +16,9 @@ varying vec3 lightDirection, eyeDirection, surfaceNormal;
 varying vec4 vColor;
 
 void main() {
-  worldCoordinate = vec3(uv.zw, f.x);
-  vec4 worldPosition = model * vec4(objectOffset + worldCoordinate, 1.0);
+  vec3 localCoordinate = vec3(uv.zw, f.x);
+  worldCoordinate = objectOffset + localCoordinate;
+  vec4 worldPosition = model * vec4(worldCoordinate, 1.0);
   vec4 clipPosition = projection * view * worldPosition;
   gl_Position = clipPosition;
   kill = f.y;

--- a/surface.js
+++ b/surface.js
@@ -94,13 +94,11 @@ function SurfacePlot (
   contourVAO,
   dynamicBuffer,
   dynamicVAO,
-  objectOffset,
-  objectScale) {
+  objectOffset) {
   this.gl = gl
   this.shape = shape
   this.bounds = bounds
   this.objectOffset = objectOffset
-  this.objectScale = objectScale
   this.intensityBounds = []
 
   this._shader = shader
@@ -726,7 +724,6 @@ proto.update = function (params) {
   params = params || {}
 
   this.objectOffset = params.objectOffset || this.objectOffset
-  this.objectScale = params.objectScale || this.objectScale
 
   this.dirty = true
 
@@ -975,12 +972,6 @@ proto.update = function (params) {
     if (params.intensityBounds) {
       lo_intensity = params.intensityBounds[0]
       hi_intensity = params.intensityBounds[1]
-
-      lo_intensity *= params.objectScale[2]
-      hi_intensity *= params.objectScale[2]
-
-      //lo_intensity -= params.objectOffset[2]
-      //hi_intensity -= params.objectOffset[2]
     }
 
     // Scale all vertex intensities
@@ -1088,8 +1079,11 @@ proto.update = function (params) {
                   var t = dy ? fy : 1.0 - fy
                   c = Math.min(Math.max(iy + dy, 0), shape[1]) | 0
 
-                  f = this._field[iu].get(r, c)
-
+                  if (axis < 2) {
+                    f = this._field[iu].get(r, c)
+                  } else {
+                    f = (this.intensity.get(r, c) - this.intensityBounds[0]) / (this.intensityBounds[1] - this.intensityBounds[0])
+                  }
                   if (!isFinite(f) || isNaN(f)) {
                     hole = true
                     break axis_loop
@@ -1343,7 +1337,6 @@ function createSurfacePlot (params) {
     dynamicBuffer,
     dynamicVAO,
     [0, 0, 0] // objectOffset
-    [1, 1, 1] // objectScale
   )
 
   var nparams = {

--- a/surface.js
+++ b/surface.js
@@ -389,8 +389,7 @@ function drawCore (params, transparent) {
     vao.bind()
 
     // Draw contour levels
-    //for (i = 0; i < 3; ++i) {
-    for (i = 2; i === 2; ++i) {
+    for (i = 0; i < 3; ++i) {
       shader.uniforms.permutation = PERMUTATIONS[i]
       gl.lineWidth(this.contourWidth[i])
 
@@ -726,9 +725,6 @@ proto.update = function (params) {
   this.objectOffset = params.objectOffset || this.objectOffset
   this.objectScale = params.objectScale || this.objectScale
 
-  console.log("this.objectOffset=", this.objectOffset);
-  console.log("this.objectScale=", this.objectScale);
-
   this.dirty = true
 
   if ('contourWidth' in params) {
@@ -1046,8 +1042,6 @@ proto.update = function (params) {
     var contourVerts = []
 
     for (var dim = 0; dim < 3; ++dim) {
-      //var otherDim = (dim + 2) % 3
-
       levels = this.contourLevels[dim]
       var levelOffsets = []
       var levelCounts = []
@@ -1080,7 +1074,7 @@ proto.update = function (params) {
 
               var offset = this.objectOffset[axis]
 
-              parts[axis] = 0.0 //+ offset
+              parts[axis] = 0.0
               var iu = (dim + axis + 1) % 3
               for (dx = 0; dx < 2; ++dx) {
                 var s = dx ? fx : 1.0 - fx
@@ -1092,9 +1086,8 @@ proto.update = function (params) {
                   if (axis < 2) {
                     f = this._field[iu].get(r, c) + offset
                   } else {
-                    f = this._field[iu].get(r, c) // + offset
+                    f = this._field[iu].get(r, c)
                     //f = (this.intensity.get(r, c) - this.intensityBounds[0]) / (this.intensityBounds[1] - this.intensityBounds[0])
-                    //f = (this.intensity.get(r, c) - this.objectOffset[0]) / (this.objectOffset[1] - this.objectOffset[0])
                   }
                   if (!isFinite(f) || isNaN(f)) {
                     hole = true
@@ -1109,11 +1102,11 @@ proto.update = function (params) {
 
             if (!hole) {
               contourVerts.push(
-                parts[0], // + this.objectOffset[0],
-                parts[1], // + this.objectOffset[1],
+                parts[0],
+                parts[1],
                 p[0],
                 p[1],
-                parts[2] //+ this.objectOffset[2]
+                parts[2]
               )
               vertexCount += 1
             } else {

--- a/surface.js
+++ b/surface.js
@@ -389,7 +389,8 @@ function drawCore (params, transparent) {
     vao.bind()
 
     // Draw contour levels
-    for (i = 0; i < 3; ++i) {
+    //for (i = 0; i < 3; ++i) {
+    for (i = 2; i === 2; ++i) {
       shader.uniforms.permutation = PERMUTATIONS[i]
       gl.lineWidth(this.contourWidth[i])
 
@@ -404,11 +405,13 @@ function drawCore (params, transparent) {
         if (!this._contourCounts[i][j]) {
           continue
         }
-        shader.uniforms.height = this.contourLevels[i][j] + this.objectOffset[i]
+
+        shader.uniforms.height = this.contourLevels[i][j] + this.objectOffset[2]
+
         vao.draw(gl.LINES, this._contourCounts[i][j], this._contourOffsets[i][j])
       }
     }
-
+/*
     // Draw projections of surface
     for (i = 0; i < 3; ++i) {
       shader.uniforms.model = projectData.projections[i]
@@ -432,8 +435,9 @@ function drawCore (params, transparent) {
         }
       }
     }
+    */
     vao.unbind()
-
+/*
     // Draw dynamic contours
     vao = this._dynamicVAO
     vao.bind()
@@ -466,6 +470,7 @@ function drawCore (params, transparent) {
     }
 
     vao.unbind()
+    */
   }
 }
 
@@ -548,7 +553,7 @@ proto.drawPick = function (params) {
 
     var vao = this._contourVAO
     vao.bind()
-
+/*
     for (j = 0; j < 3; ++j) {
       gl.lineWidth(this.contourWidth[j])
       shader.uniforms.permutation = PERMUTATIONS[j]
@@ -580,7 +585,7 @@ proto.drawPick = function (params) {
         }
       }
     }
-
+*/
     vao.unbind()
   }
 }
@@ -1087,7 +1092,7 @@ proto.update = function (params) {
                   if (axis < 2) {
                     f = this._field[iu].get(r, c) + offset
                   } else {
-                    f = this._field[iu].get(r, c) + offset
+                    f = this._field[iu].get(r, c) // + offset
                     //f = (this.intensity.get(r, c) - this.intensityBounds[0]) / (this.intensityBounds[1] - this.intensityBounds[0])
                     //f = (this.intensity.get(r, c) - this.objectOffset[0]) / (this.objectOffset[1] - this.objectOffset[0])
                   }
@@ -1095,8 +1100,6 @@ proto.update = function (params) {
                     hole = true
                     break axis_loop
                   }
-
-                  //f += this.objectOffset[2]
 
                   var w = s * t
                   parts[axis] += w * f
@@ -1137,8 +1140,12 @@ proto.update = function (params) {
 
 
     var floatBuffer = pool.mallocFloat(contourVerts.length)
-    for (i = 0; i < contourVerts.length; ++i) {
-      floatBuffer[i] = contourVerts[i]
+    for (i = 0; i < contourVerts.length; i += 5) {
+      floatBuffer[i + 0] = contourVerts[i + 0]// + this.objectOffset[0] // this.objectScale[0]
+      floatBuffer[i + 1] = contourVerts[i + 1]// + this.objectOffset[1] // this.objectScale[1]
+      floatBuffer[i + 2] = contourVerts[i + 2]
+      floatBuffer[i + 3] = contourVerts[i + 3]
+      floatBuffer[i + 4] = contourVerts[i + 4]
     }
     this._contourBuffer.update(floatBuffer)
     pool.freeFloat(floatBuffer)

--- a/surface.js
+++ b/surface.js
@@ -1021,6 +1021,11 @@ proto.update = function (params) {
         return a - b
       })
     }
+    for (i = 0; i < 3; ++i) {
+      for (j = 0; j < levels[i].length; ++j) {
+        levels[i][j] -= this.objectOffset[i]
+      }
+    }
     change_test:
     for (i = 0; i < 3; ++i) {
       if (levels[i].length !== this.contourLevels[i].length) {
@@ -1083,12 +1088,8 @@ proto.update = function (params) {
                   var t = dy ? fy : 1.0 - fy
                   c = Math.min(Math.max(iy + dy, 0), shape[1]) | 0
 
-                  if (axis < 2) {
-                    f = this._field[iu].get(r, c)
-                  } else {
-                    f = this._field[iu].get(r, c)
-                    //f = (this.intensity.get(r, c) - this.intensityBounds[0]) / (this.intensityBounds[1] - this.intensityBounds[0])
-                  }
+                  f = this._field[iu].get(r, c)
+
                   if (!isFinite(f) || isNaN(f)) {
                     hole = true
                     break axis_loop
@@ -1160,6 +1161,8 @@ proto.dispose = function () {
 }
 
 proto.highlight = function (selection) {
+  var i
+
   if (!selection) {
     this._dynamicCounts = [0, 0, 0]
     this.dyanamicLevel = [NaN, NaN, NaN]
@@ -1167,7 +1170,7 @@ proto.highlight = function (selection) {
     return
   }
 
-  for (var i = 0; i < 3; ++i) {
+  for (i = 0; i < 3; ++i) {
     if (this.enableHighlight[i]) {
       this.highlightLevel[i] = selection.level[i]
     } else {
@@ -1180,6 +1183,9 @@ proto.highlight = function (selection) {
     levels = selection.dataCoordinate
   } else {
     levels = selection.position
+  }
+  for (i = 0; i < 3; ++i) {
+    levels[i] -= this.objectOffset[i]
   }
   if ((!this.enableDynamic[0] || levels[0] === this.dynamicLevel[0]) &&
     (!this.enableDynamic[1] || levels[1] === this.dynamicLevel[1]) &&

--- a/surface.js
+++ b/surface.js
@@ -939,9 +939,13 @@ proto.update = function (params) {
           ny = normals.get(r + 1, c + 1, 1)
           nz = normals.get(r + 1, c + 1, 2)
 
-          var vf = (!params.intensity) ?
-            f + this.objectOffset[2] :
-            params.intensity.get(r, c);
+          if (params.intensity) {
+            vf = params.intensity.get(r, c)
+          }
+
+          var vf = (params.intensity) ?
+            params.intensity.get(r, c) :
+            f + this.objectOffset[2];
 
           tverts[tptr++] = r
           tverts[tptr++] = c
@@ -970,8 +974,8 @@ proto.update = function (params) {
     }
 
     if (params.intensityBounds) {
-      lo_intensity = params.intensityBounds[0]
-      hi_intensity = params.intensityBounds[1]
+      lo_intensity = +params.intensityBounds[0]
+      hi_intensity = +params.intensityBounds[1]
     }
 
     // Scale all vertex intensities

--- a/surface.js
+++ b/surface.js
@@ -94,13 +94,13 @@ function SurfacePlot (
   contourVAO,
   dynamicBuffer,
   dynamicVAO,
-  worldOffset,
-  worldScale) {
+  objectOffset,
+  objectScale) {
   this.gl = gl
   this.shape = shape
   this.bounds = bounds
-  this.worldOffset = worldOffset
-  this.worldScale = worldScale
+  this.objectOffset = objectOffset
+  this.objectScale = objectScale
   this.intensityBounds = []
 
   this._shader = shader
@@ -718,8 +718,8 @@ function handleColor (param) {
 proto.update = function (params) {
   params = params || {}
 
-  this.worldOffset = params.worldOffset
-  this.worldScale = params.worldScale
+  this.objectOffset = params.objectOffset
+  this.objectScale = params.objectScale
 
   this.dirty = true
 
@@ -927,9 +927,9 @@ proto.update = function (params) {
           var r = i + QUAD[k][0]
           var c = j + QUAD[k][1]
 
-          var tx = this._field[0].get(r + 1, c + 1) + this.worldOffset[0]
-          var ty = this._field[1].get(r + 1, c + 1) + this.worldOffset[1]
-          f =      this._field[2].get(r + 1, c + 1) + this.worldOffset[2]
+          var tx = this._field[0].get(r + 1, c + 1) + this.objectOffset[0]
+          var ty = this._field[1].get(r + 1, c + 1) + this.objectOffset[1]
+          f =      this._field[2].get(r + 1, c + 1) + this.objectOffset[2]
           var vf = f
           nx = normals.get(r + 1, c + 1, 0)
           ny = normals.get(r + 1, c + 1, 1)
@@ -969,11 +969,11 @@ proto.update = function (params) {
       lo_intensity = params.intensityBounds[0]
       hi_intensity = params.intensityBounds[1]
 
-      lo_intensity *= params.worldScale[2]
-      hi_intensity *= params.worldScale[2]
+      lo_intensity *= params.objectScale[2]
+      hi_intensity *= params.objectScale[2]
 
-      //lo_intensity -= params.worldOffset[2]
-      //hi_intensity -= params.worldOffset[2]
+      //lo_intensity -= params.objectOffset[2]
+      //hi_intensity -= params.objectOffset[2]
     }
 
     // Scale all vertex intensities
@@ -1320,8 +1320,8 @@ function createSurfacePlot (params) {
     contourVAO,
     dynamicBuffer,
     dynamicVAO,
-    [0, 0, 0] // worldOffset
-    [1, 1, 1] // worldScale
+    [0, 0, 0] // objectOffset
+    [1, 1, 1] // objectScale
   )
 
   var nparams = {


### PR DESCRIPTION
In this PR one calling attribute is added that make it possible for the user to calculate and pass a reference point within the data (e.g. the center) while creating the surface. Then this info is passed to the contour program and shaders. For more info please refer to [Plotly PR](https://github.com/plotly/plotly.js/pull/3281).
@etpinard 
