### PR TITLE
Improve numerical stability of projection

### DIFF
--- a/shaders/contour-vertex.glsl
+++ b/shaders/contour-vertex.glsl
@@ -20,7 +20,7 @@ void main() {
   worldCoordinate = objectOffset + dataCoordinate;
   vec4 worldPosition = model * vec4(worldCoordinate, 1.0);
 
-  vec4 clipPosition = projection * view * worldPosition;
+  vec4 clipPosition = projection * (view * worldPosition);
   clipPosition.z += zOffset;
 
   gl_Position = clipPosition;

--- a/shaders/vertex.glsl
+++ b/shaders/vertex.glsl
@@ -19,7 +19,7 @@ void main() {
   vec3 localCoordinate = vec3(uv.zw, f.x);
   worldCoordinate = objectOffset + localCoordinate;
   vec4 worldPosition = model * vec4(worldCoordinate, 1.0);
-  vec4 clipPosition = projection * view * worldPosition;
+  vec4 clipPosition = projection * (view * worldPosition);
   gl_Position = clipPosition;
   kill = f.y;
   value = f.z;


### PR DESCRIPTION
When the position vector has large values that are cancelled out by large values in the model matrix, it is more numerically stable to first multiply the position by the model matrix instead of multiplying the matrices together first.

This should always yield equivalent or more accurate results.

Helps with https://github.com/plotly/plotly.js/issues/3306
See https://github.com/gl-vis/gl-axes3d/pull/23