### PR TITLE
Improve precision of surface3d worldPosition calculation

### DIFF
--- a/shaders/contour-vertex.glsl
+++ b/shaders/contour-vertex.glsl
@@ -18,7 +18,8 @@ varying vec4 vColor;
 void main() {
   vec3 dataCoordinate = permutation * vec3(uv.xy, height);
   worldCoordinate = objectOffset + dataCoordinate;
-  vec4 worldPosition = model * vec4(worldCoordinate, 1.0);
+  mat4 objectOffsetTranslation = mat4(1.0) + mat4(vec4(0), vec4(0), vec4(0), vec4(objectOffset, 0));
+  vec4 worldPosition = (model * objectOffsetTranslation) * vec4(dataCoordinate, 1.0);
 
   vec4 clipPosition = projection * (view * worldPosition);
   clipPosition.z += zOffset;

--- a/shaders/vertex.glsl
+++ b/shaders/vertex.glsl
@@ -18,7 +18,8 @@ varying vec4 vColor;
 void main() {
   vec3 localCoordinate = vec3(uv.zw, f.x);
   worldCoordinate = objectOffset + localCoordinate;
-  vec4 worldPosition = model * vec4(worldCoordinate, 1.0);
+  mat4 objectOffsetTranslation = mat4(1.0) + mat4(vec4(0), vec4(0), vec4(0), vec4(objectOffset, 0));
+  vec4 worldPosition = (model * objectOffsetTranslation) * vec4(localCoordinate, 1.0);
   vec4 clipPosition = projection * (view * worldPosition);
   gl_Position = clipPosition;
   kill = f.y;


### PR DESCRIPTION
When the objectOffset is very large compared to the values in the localCoordinate, adding it to the localCoordinate loses precision in the localCoordinate. As the addition of the objectOffset was immediately undone by application of the model matrix, it is better to combine the model matrix and the translation by the objectOffset into one matrix and apply it directly to the localCoordinate.

See https://github.com/plotly/plotly.js/pull/6999